### PR TITLE
Make *_exists functions compatible with psycopg2.extras.NamedTupleCursor

### DIFF
--- a/pony/orm/dbproviders/postgres.py
+++ b/pony/orm/dbproviders/postgres.py
@@ -225,7 +225,7 @@ class PGProvider(DBAPIProvider):
                     'WHERE schemaname = %s AND lower(tablename) = lower(%s)'
         cursor.execute(sql, (schema_name, table_name))
         row = cursor.fetchone()
-        return row[0] if row is not None else None
+        return row
 
     def index_exists(provider, connection, table_name, index_name, case_sensitive=True):
         schema_name, table_name = provider.split_table_name(table_name)

--- a/pony/orm/dbproviders/postgres.py
+++ b/pony/orm/dbproviders/postgres.py
@@ -184,8 +184,8 @@ class PGProvider(DBAPIProvider):
                     'WHERE schemaname = %s AND lower(tablename) = lower(%s)'
         cursor.execute(sql, (schema_name, table_name))
         row = cursor.fetchone()
-        return row[0] if row is not None else None
-    
+        return row
+
     def index_exists(provider, connection, table_name, index_name, case_sensitive=True):
         schema_name, table_name = provider.split_table_name(table_name)
         cursor = connection.cursor()
@@ -195,7 +195,7 @@ class PGProvider(DBAPIProvider):
                     'WHERE schemaname = %s AND tablename = %s AND lower(indexname) = lower(%s)'
         cursor.execute(sql, [ schema_name, table_name, index_name ])
         row = cursor.fetchone()
-        return row[0] if row is not None else None
+        return row
 
     def fk_exists(provider, connection, table_name, fk_name, case_sensitive=True):
         schema_name, table_name = provider.split_table_name(table_name)
@@ -212,7 +212,7 @@ class PGProvider(DBAPIProvider):
         cursor = connection.cursor()
         cursor.execute(sql, [ schema_name, table_name, fk_name ])
         row = cursor.fetchone()
-        return row[0] if row is not None else None
+        return row
 
     def table_has_data(provider, connection, table_name):
         table_name = provider.quote_name(table_name)


### PR DESCRIPTION
Pony supports passing connect parameters to database providers, which
allows one to use psycopg2.extras.NamedTupleCursor for getting named
tuples back from db.execute().  However, some functions in the postgres
provider fail because of the way it's checking for existence of database
objects.  This patch simplifies these checks so the namedtuple cursor
can be used.
