### PR TITLE
Sqlite row factory param

### DIFF
--- a/pony/orm/dbproviders/postgres.py
+++ b/pony/orm/dbproviders/postgres.py
@@ -184,8 +184,8 @@ class PGProvider(DBAPIProvider):
                     'WHERE schemaname = %s AND lower(tablename) = lower(%s)'
         cursor.execute(sql, (schema_name, table_name))
         row = cursor.fetchone()
-        return row[0] if row is not None else None
-    
+        return row
+
     def index_exists(provider, connection, table_name, index_name, case_sensitive=True):
         schema_name, table_name = provider.split_table_name(table_name)
         cursor = connection.cursor()
@@ -195,7 +195,7 @@ class PGProvider(DBAPIProvider):
                     'WHERE schemaname = %s AND tablename = %s AND lower(indexname) = lower(%s)'
         cursor.execute(sql, [ schema_name, table_name, index_name ])
         row = cursor.fetchone()
-        return row[0] if row is not None else None
+        return row
 
     def fk_exists(provider, connection, table_name, fk_name, case_sensitive=True):
         schema_name, table_name = provider.split_table_name(table_name)
@@ -212,7 +212,7 @@ class PGProvider(DBAPIProvider):
         cursor = connection.cursor()
         cursor.execute(sql, [ schema_name, table_name, fk_name ])
         row = cursor.fetchone()
-        return row[0] if row is not None else None
+        return row
 
     def table_has_data(provider, connection, table_name):
         table_name = provider.quote_name(table_name)


### PR DESCRIPTION
The sqlite3 driver allows for a row_factory parameter to connections
that lets one set a factory function for result rows.  This change
allows that parameter to be set when binding to a database so that one
can, for instance, get namedtuples back instead of tuples with no field
names.
