### PR TITLE
Add the compatibility with PYPY by psycopg2cffi.

### DIFF
--- a/pony/orm/dbproviders/postgres.py
+++ b/pony/orm/dbproviders/postgres.py
@@ -5,7 +5,12 @@ from decimal import Decimal
 from datetime import datetime, date, time, timedelta
 from uuid import UUID
 
-import psycopg2
+try:
+    import psycopg2
+except ImportError:
+    from psycopg2cffi import compat
+    compat.register()
+
 from psycopg2 import extensions
 
 import psycopg2.extras


### PR DESCRIPTION
It is unable to install psycopg2 when using pypy. I use the lib psycopg2cffi in order to make pony works.

Steps:

+ install pypy-dev;
+ pip install psycopg2cffi.

SEE:

http://stackoverflow.com/questions/9350422/how-do-you-get-pypy-django-and-postgresql-to-work-together#