### PR TITLE
Added documentation in docstrings

### DIFF
--- a/pony/orm/core.py
+++ b/pony/orm/core.py
@@ -872,7 +872,7 @@ class Database(object):
         if PY2 and type(new_id) is long: new_id = int(new_id)
         return new_id
     @cut_traceback
-    def generate_mapping(database, filename=None, check_tables=True, (create_tables)=False):
+    def generate_mapping(database, filename=None, check_tables=True, create_tables=False):
         """Map declared entities to the corresponding tables in the database.
         Creates tables, foreign key references and indexes if necessary."""
         provider = database.provider


### PR DESCRIPTION
I used Pony for the first time to do a small project that works with a database. I found it difficult to decipher, having to go back and forth to the documentation instead of having it in the codebase.

I just copied and pasted the documentation from the API Reference section of the Pony docs into docstrings, along with the given examples.

Tests were run to ensure nothing was broken in the process.