### PR TITLE
Fix issue with unicode json path keys

### DIFF
--- a/pony/orm/sqlbuilding.py
+++ b/pony/orm/sqlbuilding.py
@@ -549,7 +549,7 @@ class SQLBuilder(object):
         empty_slice = slice(None, None, None)
         for value in values:
             if isinstance(value, int): append('[%d]' % value)
-            elif isinstance(value, str):
+            elif isinstance(value, str) or isinstance(value, unicode):
                 append('.' + value if is_ident(value) else '."%s"' % value.replace('"', '\\"'))
             elif value is Ellipsis: append('.*')
             elif value == empty_slice: append('[*]')


### PR DESCRIPTION
This fixes an issue with unicode keys in JSON path. I observed the bug on Python 2.7.11.

The previous implementation of `SQLBuilder.eval_json_path()` did not consider unicode objects valid keys.

Here is some sample code which should reproduce the issue.
```
from pony.orm import *

db = Database()

class MyEntity(db.Entity):
    id = PrimaryKey(int, auto=True)
    json = Optional(Json

...

def query_json():
    with db_session:
        my_entities = select(e for e in MyEntity if e.json[u'key'] == 'value')[:]

    return my_entities
```

I ran into this issue because I am developing a Python 2/3 codebase using the unicode literals feature from [future](http://python-future.org/). The workaround I am using for now is as follows:

```
from __future__ import unicode_literals

import sys
PY2 = sys.version_info[0] == 2

...

def _json_key(key):
    return bytes(key) if PY2 else key

def query_json():
    with db_session:
        my_entities = select(e for e in MyEntity if e.json[_json_key('key')] == 'value')[:]

    return my_entities
```

