### PR TITLE
Migrate sqlite

### DIFF
--- a/pony/migrate/executor.py
+++ b/pony/migrate/executor.py
@@ -71,11 +71,13 @@ class Executor(object):
                 for prev_attr in prev_entity._new_attrs_:
                     new_attr = prev_attr.new_attr
                     if new_attr is not None and not (prev_attr.is_collection or new_attr.is_collection):
-                        assert len(prev_attr.columns) == len(new_attr.columns)
-                        assert len(prev_attr.column_objects) == len(new_attr.column_objects)
-                        for prev_col, new_col in zip(prev_attr.column_objects, new_attr.column_objects):
-                            prev_col.new = new_col
-                            new_col.prev = prev_col
+                        # one-to-one pairs will have column_objects both equal to None
+                        if prev_attr.column_objects is not None and new_attr.column_objects is not None:
+                            assert len(prev_attr.columns) == len(new_attr.columns)
+                            assert len(prev_attr.column_objects) == len(new_attr.column_objects)
+                            for prev_col, new_col in zip(prev_attr.column_objects, new_attr.column_objects):
+                                prev_col.new = new_col
+                                new_col.prev = prev_col
 
         for prev_constraint in self.prev_schema.constraints.values():
             new_constrant = self.new_schema.constraints.get(prev_constraint.name)

--- a/pony/migrate/serializer.py
+++ b/pony/migrate/serializer.py
@@ -143,7 +143,7 @@ class Serializer(object):
         lines = [ 'class %s(%s):' % (name, ', '.join(_bases)) ]
 
         for name, value in cls_dict.items():
-            if name in ('__slots__', '__qualname__', '__module__', '_indexes_'): continue
+            if name in ('__slots__', '__qualname__', '__module__', '_indexes_', '__classcell__'): continue
             if isinstance(value, (core.Attribute, types.MethodType, types.FunctionType,
                                   staticmethod, classmethod, property)): continue
             lines.append('%s = %s' % (name, self.serialize(value)))
@@ -236,7 +236,7 @@ class Serializer(object):
         if isinstance(value, decimal.Decimal):
             return self.serialize_basic(value, 'from decimal import Decimal')
         if isinstance(value, functools.partial):
-             return self.serialize_partial(value)
+            return self.serialize_partial(value)
         if isinstance(value, (types.FunctionType, types.BuiltinFunctionType)):
             return self.serialize_function(value)
         if isinstance(value, collections.Iterable):

--- a/pony/orm/dbproviders/sqlite.py
+++ b/pony/orm/dbproviders/sqlite.py
@@ -45,7 +45,7 @@ class SQLiteTable(dbschema.Table):
         batch = OperationBatch(type='rename')
         index_ops = []
 
-        original_table_name = table.name
+        table._name = table.name # Preserve the original table name for foreign key references to the same table
         tmp_name = table.name + '__new'
 
         table.name = tmp_name
@@ -55,7 +55,8 @@ class SQLiteTable(dbschema.Table):
                 continue
             sql = index.get_create_command()
             index_ops.append(Op(sql, obj=index, type='create'))
-        table.name = original_table_name
+        table.name = table._name
+        table._name = None
 
         quote_name = table.schema.provider.quote_name
 

--- a/pony/orm/dbschema.py
+++ b/pony/orm/dbschema.py
@@ -121,6 +121,7 @@ class Table(DBObject):
         schema.names[name] = table
         table.schema = schema
         table.name = name
+        table._name = None # Foreign keys need the old name to remap to
         table.prev = table.new = None
         table.column_list = []
         table.column_dict = {}
@@ -404,7 +405,10 @@ class Column(object):
             if fk is not None:
                 parent_table = fk.parent_table
                 append('REFERENCES')
-                append(quote_name(parent_table.name))
+                if parent_table._name is None:
+                    append(quote_name(parent_table.name))
+                else:
+                    append(quote_name(parent_table._name))
                 append(schema.names_row(fk.parent_col_names))
         return ' '.join(result)
 
@@ -624,7 +628,10 @@ class ForeignKey(Constraint):
         append('FOREIGN KEY')
         append(schema.names_row(fk.col_names))
         append('REFERENCES')
-        append(quote_name(fk.parent_table.name))
+        if fk.parent_table._name is None:
+            append(quote_name(fk.parent_table.name))
+        else:
+            append(quote_name(fk.parent_table._name))
         append(schema.names_row(fk.parent_col_names))
         return ' '.join(cmd)
     def get_drop_ops(foreign_key):


### PR DESCRIPTION
I've recently been using Pony ORM on a project at my workplace. I love it's flexibility in Python and have been refactoring my project to start using it. When I switched over to using the migrations branch I noticed an issue on my first migration after the initial one. When ever a table uses a foreign key in reference to itself it incorrectly gets stored as [table name]__new in the foreign key. After that happens any attempt to add entries to the database table results in an OperationalError: no such table: main.[table]__new

I've made an example script that's a stripped down example version of my bigger project that demonstrates the issue. Running it once, then uncommenting the second Segment sub-class and running it again for the first migration attempt leaves an incorrect foreign key in the schema:
```
import os
from datetime import datetime, date, time
from pony.orm import Database, db_session, Discriminator, Required, Optional, Set, set_sql_debug
from pony.migrate.command import migrate

db = Database()
set_sql_debug(True)

class Segment(db.Entity):
    seg_type = Discriminator(str)
    _discriminator_ = 'SEGMENT'
    parent_segment = Optional('Segment', reverse='child_segments')
    child_segments = Set('Segment',      reverse='parent_segment', cascade_delete=True)

class DTM(Segment):
    _discriminator_ = 'DTM'
    DTM_qual        = Required(str, default='ZZZ')
    DTM_date        = Optional(date)
    DTM_time        = Optional(time)
    DTM_time_code   = Optional(str)
    DTM_period_qual = Optional(str)
    DTM_period      = Optional(str, max_len=35)

# class PER(Segment):
#     _discriminator_ = 'PER'
#         
#     PER_contact_type  = Required(str, default='ZZ')
#     PER_name          = Optional(str, max_len=60)
#     PER_comm1_qual    = Optional(str)
#     PER_comm2_qual    = Optional(str)
#     PER_comm3_qual    = Optional(str)
#     PER_comm1_num     = Optional(str, max_len=80)
#     PER_comm2_num     = Optional(str, max_len=80)
#     PER_comm3_num     = Optional(str, max_len=80)
#     PER_inquiry_ref   = Optional(str, max_len=20)

mig_dir = os.path.join(os.getcwd(), 'FK_migrations')
if not os.path.exists(mig_dir):
    os.makedirs(mig_dir, exist_ok=True)
os.environ['MIGRATIONS_DIR'] = mig_dir
db.bind('sqlite', os.path.join(os.getcwd(), 'EDI.db'), create_db=True)
db.generate_mapping(check_tables=False, allow_auto_upgrade=True)
migrate(db, 'make')
migrate(db, 'apply')

with db_session:
    now = datetime.now()
    test_datetime = db.DTM(
        DTM_date = now.date(),
        DTM_time = now.time()
    )
```

This is the schema it generates during the migration in the console with debug enabled:
```
CREATE TABLE "segment__new" (
  "id" INTEGER CONSTRAINT "pk_segment" PRIMARY KEY AUTOINCREMENT,
  "seg_type" TEXT NOT NULL,
  "parent_segment" INTEGER REFERENCES "segment__new" ("id"),
  "dtm_qual" TEXT,
  "dtm_date" DATE,
  "dtm_time" TIME,
  "dtm_time_code" TEXT,
  "dtm_period_qual" TEXT,
  "dtm_period" VARCHAR(35),
  "per_comm1_num" VARCHAR(80),
  "per_comm1_qual" TEXT,
  "per_comm2_num" VARCHAR(80),
  "per_comm2_qual" TEXT,
  "per_comm3_num" VARCHAR(80),
  "per_comm3_qual" TEXT,
  "per_contact_type" TEXT,
  "per_inquiry_ref" VARCHAR(20),
  "per_name" VARCHAR(60)
)
```
And resulting traceback:
Traceback (most recent call last):
  File "FK_Test.py", line 53, in <module>
    DTM_time = now.time()
  File "C:\Users\Lane\Documents\Git\pony\orm\core.py", line 439, in __exit__
    commit()
  File "C:\Users\Lane\Documents\Git\pony\orm\core.py", line 334, in commit
    rollback_and_reraise(sys.exc_info())
  File "C:\Users\Lane\Documents\Git\pony\orm\core.py", line 323, in rollback_and_reraise
    reraise(*exc_info)
  File "C:\Users\Lane\Documents\Git\pony\utils\utils.py", line 95, in reraise
    try: raise exc.with_traceback(tb)
  File "C:\Users\Lane\Documents\Git\pony\orm\core.py", line 332, in commit
    cache.flush()
  File "C:\Users\Lane\Documents\Git\pony\orm\core.py", line 1724, in flush
    if obj is not None: obj._save_()
  File "C:\Users\Lane\Documents\Git\pony\orm\core.py", line 5368, in _save_
    if status == 'created': obj._save_created_()
  File "C:\Users\Lane\Documents\Git\pony\orm\core.py", line 5216, in _save_created_
    % (obj, e.__class__.__name__, msg), e)
  File "C:\Users\Lane\Documents\Git\pony\utils\utils.py", line 106, in throw
    raise exc
pony.orm.core.UnexpectedError: Object DTM[new:2] cannot be stored in the database. OperationalError: no such table: main.segment__new
