### PR TITLE
Fix test_operations.py in orm-migrations branch

### DIFF
--- a/pony/orm/examples/test_operations.py
+++ b/pony/orm/examples/test_operations.py
@@ -1,5 +1,6 @@
+from __future__ import print_function
 from pony.orm import *
-from pony.orm.migrating.diagram_ops import *
+from pony.migrate import diagram_ops as ops
 
 def define_db_1():
     db = Database('sqlite', ':memory:')
@@ -11,7 +12,7 @@ def define_db_1():
 
 db = define_db_1()
 
-op = AddAttr('Person', 'age', Required(int))
+op = ops.AddAttr('Person', 'age', Required(int))
 op.apply(db)
 
 assert isinstance(db.Person.age, Required)
@@ -27,35 +28,34 @@ db = define_db_1()
 
 db.generate_mapping(check_tables=False)
 
-op = AddAttr('Person', 'age', Required(int, unique=True))
+op = ops.AddAttr('Person', 'age', Required(int, unique=True))
 op.apply(db)
 
 assert isinstance(db.Person.age, Required)
 assert db.Person.age.py_type is int
 
-print db.schema.generate_create_script()
+print(db.schema.generate_create_script())
 
 db = define_db_1()
 
-op = AddEntity('Contact', (), [('type', Required(str)), ('value', Required(str))])
+op = ops.AddEntity('Contact', (), [('type', Required(str)), ('value', Required(str))])
 op.apply(db)
 
 db.generate_mapping(check_tables=False)
 
-print db.schema.generate_create_script()
+print(db.schema.generate_create_script())
 
 
 db = define_db_1()
 db.migration_in_progress = True
 
-op = AddEntity('Contact', (), [('type', Required(str)), ('value', Required(str))])
+op = ops.AddEntity('Contact', (), [('type', Required(str)), ('value', Required(str))])
 op.apply(db)
 
-op = AddRelation('Person', 'contacts', Set('Contact'), 'Contact', 'person', Required('Person'))
+
+op = ops.AddRelation('Person', 'contacts', Set('Contact'), 'person', Required('Person'))
 op.apply(db)
 
 db.generate_mapping(check_tables=False)
 
-print db.schema.generate_create_script()
-
-print db.schema.tables['Contact'].foreign_keys
+print(db.schema.tables['contact'].foreign_keys)


### PR DESCRIPTION
This is a little thing I noticed when running `PYTHONPATH=../ponytest/ python3 -m unittest discover -v`. I know it isn't a test but figure there is no harm fixing it.

Before:
pony$ python2 pony/orm/examples/test_operations.py
Traceback (most recent call last):
  File "pony/orm/examples/test_operations.py", line 2, in <module>
    from pony.orm.migrating.diagram_ops import *
ImportError: No module named migrating.diagram_ops

pony$ python3 pony/orm/examples/test_operations.py
  File "pony/orm/examples/test_operations.py", line 36
    print db.schema.generate_create_script()
           ^
SyntaxError: invalid syntax

After:
pony$ python2 pony/orm/examples/test_operations.py
class Person(Entity):
    id = PrimaryKey(int, auto=True)
    name = Required(str)
    age = Required(int)
()
CREATE TABLE "person" (
  "id" INTEGER CONSTRAINT "pk_person" PRIMARY KEY AUTOINCREMENT,
  "name" TEXT NOT NULL,
  "age" INTEGER UNIQUE NOT NULL
)
CREATE TABLE "contact" (
  "id" INTEGER CONSTRAINT "pk_contact" PRIMARY KEY AUTOINCREMENT,
  "type" TEXT NOT NULL,
  "value" TEXT NOT NULL
);

CREATE TABLE "person" (
  "id" INTEGER CONSTRAINT "pk_person" PRIMARY KEY AUTOINCREMENT,
  "name" TEXT NOT NULL
)
{(u'person',): <pony.orm.dbproviders.sqlite.SQLiteForeignKey object at 0x7f6eb387e390>}

pony$ python3 pony/orm/examples/test_operations.py
(same as python 2)