### PR TITLE
added enum support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ pony/orm/tests/coverage.bat
 pony/orm/tests/htmlcov/*.*
 MANIFEST
 docs/_build/
+.DS_Store
+.eggs/
+build/
+dist/
+pony.egg-info/

--- a/pony/orm/dbapiprovider.py
+++ b/pony/orm/dbapiprovider.py
@@ -4,6 +4,7 @@ from pony.py23compat import PY2, basestring, unicode, buffer, int_types, iterite
 import os, re, json
 from decimal import Decimal, InvalidOperation
 from datetime import datetime, date, time, timedelta
+from enum import Enum
 from uuid import uuid4, UUID
 
 import pony
@@ -416,6 +417,20 @@ class BoolConverter(Converter):
         return bool(val)
     def sql_type(converter):
         return "BOOLEAN"
+
+class EnumConverter(Converter):
+    def validate(self, val, obj=None):
+        if isinstance(val, Enum): return val
+        raise TypeError('EnumConverter expected type Enum but got %r' % (type(val)))
+
+    def py2sql(self, val):
+        return val.name
+
+    def sql2py(self, val):
+        return self.py_type[val]
+
+    def sql_type(self):
+        return 'TEXT'
 
 class StrConverter(Converter):
     def __init__(converter, provider, py_type, attr=None):

--- a/pony/orm/dbproviders/mysql.py
+++ b/pony/orm/dbproviders/mysql.py
@@ -4,6 +4,7 @@ from pony.py23compat import PY2, imap, basestring, buffer, int_types
 import json
 from decimal import Decimal
 from datetime import datetime, date, time, timedelta
+from enum import Enum
 from uuid import UUID
 
 NoneType = type(None)
@@ -211,6 +212,7 @@ class MySQLProvider(DBAPIProvider):
         (UUID, MySQLUuidConverter),
         (buffer, MySQLBlobConverter),
         (ormtypes.Json, MySQLJsonConverter),
+        (Enum, dbapiprovider.EnumConverter)
     ]
 
     def normalize_name(provider, name):

--- a/pony/orm/dbproviders/oracle.py
+++ b/pony/orm/dbproviders/oracle.py
@@ -7,6 +7,7 @@ os.environ["NLS_LANG"] = "AMERICAN_AMERICA.UTF8"
 import re
 from datetime import datetime, date, time, timedelta
 from decimal import Decimal
+from enum import Enum
 from uuid import UUID
 
 import cx_Oracle
@@ -414,6 +415,7 @@ class OraProvider(DBAPIProvider):
         (UUID, OraUuidConverter),
         (buffer, OraBlobConverter),
         (Json, OraJsonConverter),
+        (Enum, dbapiprovider.EnumConverter)
     ]
 
     @wrap_dbapi_exceptions

--- a/pony/orm/dbproviders/postgres.py
+++ b/pony/orm/dbproviders/postgres.py
@@ -3,6 +3,7 @@ from pony.py23compat import PY2, basestring, unicode, buffer, int_types
 
 from decimal import Decimal
 from datetime import datetime, date, time, timedelta
+from enum import Enum
 from uuid import UUID
 
 try:
@@ -290,6 +291,7 @@ class PGProvider(DBAPIProvider):
         (UUID, PGUuidConverter),
         (buffer, PGBlobConverter),
         (ormtypes.Json, PGJsonConverter),
+        (Enum, dbapiprovider.EnumConverter)
     ]
 
 provider_cls = PGProvider

--- a/pony/orm/dbproviders/sqlite.py
+++ b/pony/orm/dbproviders/sqlite.py
@@ -5,6 +5,7 @@ import os.path, sys, re, json
 import sqlite3 as sqlite
 from decimal import Decimal
 from datetime import datetime, date, time, timedelta
+from enum import Enum
 from random import random
 from time import strptime
 from threading import Lock
@@ -258,7 +259,8 @@ class SQLiteProvider(DBAPIProvider):
         (timedelta, SQLiteTimedeltaConverter),
         (UUID, dbapiprovider.UuidConverter),
         (buffer, dbapiprovider.BlobConverter),
-        (Json, SQLiteJsonConverter)
+        (Json, SQLiteJsonConverter),
+        (Enum, dbapiprovider.EnumConverter)
     ]
 
     def __init__(provider, *args, **kwargs):

--- a/pony/orm/ormtypes.py
+++ b/pony/orm/ormtypes.py
@@ -203,6 +203,7 @@ def normalize_type(t):
     if t in (slice, type(Ellipsis)): return t
     if issubclass(t, basestring): return unicode
     if issubclass(t, (dict, Json)): return Json
+    if tt.__name__ == 'EnumMeta': return t
     throw(TypeError, 'Unsupported type %r' % t.__name__)
 
 coercions = {
@@ -263,6 +264,8 @@ def are_comparable_types(t1, t2, op='=='):
             return False
         if tt1.__name__ == tt2.__name__ == 'EntityMeta':
             return t1._root_ is t2._root_
+        if tt1.__name__ == tt2.__name__ == 'EnumMeta':
+            return t1.__name__ == t2.__name__
         return False
     if t1 is t2 and t1 in comparable_types: return True
     return (t1, t2) in coercions

--- a/pony/orm/sqltranslation.py
+++ b/pony/orm/sqltranslation.py
@@ -4,6 +4,7 @@ from pony.py23compat import PY2, items_list, izip, xrange, basestring, unicode, 
 import types, sys, re, itertools, inspect
 from decimal import Decimal
 from datetime import date, time, datetime, timedelta
+from enum import Enum
 from random import random
 from copy import deepcopy
 from functools import update_wrapper
@@ -1694,6 +1695,9 @@ class BufferMixin(MonadMixin):
 class UuidMixin(MonadMixin):
     pass
 
+class EnumMixin(MonadMixin):
+    pass
+
 _binop_errmsg = 'Unsupported operand types %r and %r for operation %r in expression: {EXPR}'
 
 def make_numeric_binop(op, sqlop):
@@ -2071,6 +2075,7 @@ class AttrMonad(Monad):
         elif type is UUID: cls = UuidAttrMonad
         elif type is Json: cls = JsonAttrMonad
         elif isinstance(type, EntityMeta): cls = ObjectAttrMonad
+        elif issubclass(type, Enum): cls = EnumAttrMonad
         else: throw(NotImplementedError, type)  # pragma: no cover
         return cls(parent, attr, *args, **kwargs)
     def __new__(cls, *args):
@@ -2124,6 +2129,7 @@ class DatetimeAttrMonad(DatetimeMixin, AttrMonad): pass
 class BufferAttrMonad(BufferMixin, AttrMonad): pass
 class UuidAttrMonad(UuidMixin, AttrMonad): pass
 class JsonAttrMonad(JsonMixin, AttrMonad): pass
+class EnumAttrMonad(EnumMixin, AttrMonad): pass
 
 class ParamMonad(Monad):
     @staticmethod
@@ -2139,6 +2145,7 @@ class ParamMonad(Monad):
         elif type is UUID: cls = UuidParamMonad
         elif type is Json: cls = JsonParamMonad
         elif isinstance(type, EntityMeta): cls = ObjectParamMonad
+        elif issubclass(type, Enum): cls = EnumParamMonad
         else: throw(NotImplementedError, 'Parameter {EXPR} has unsupported type %r' % (type,))
         result = cls(type, paramkey)
         result.aggregated = False
@@ -2180,6 +2187,7 @@ class TimedeltaParamMonad(TimedeltaMixin, ParamMonad): pass
 class DatetimeParamMonad(DatetimeMixin, ParamMonad): pass
 class BufferParamMonad(BufferMixin, ParamMonad): pass
 class UuidParamMonad(UuidMixin, ParamMonad): pass
+class EnumParamMonad(EnumMixin, ParamMonad): pass
 
 class JsonParamMonad(JsonMixin, ParamMonad):
     def getsql(monad, sqlquery=None):

--- a/pony/orm/tests/test_enum.py
+++ b/pony/orm/tests/test_enum.py
@@ -1,0 +1,50 @@
+import unittest
+
+from enum import Enum
+from pony.orm import Database, Required, db_session, select
+
+db = Database('sqlite', ':memory:')
+
+
+class Result(Enum):
+    SUCCESS = 0
+    FAILURE = 1
+    UNKNOWN = 2
+
+
+class Test(db.Entity):
+    name = Required(str)
+    result = Required(Result)
+
+db.generate_mapping(create_tables=True)
+
+with db_session:
+    Test(name="one", result=Result.SUCCESS)
+    Test(name="two", result=Result.FAILURE)
+    Test(name="three", result=Result.UNKNOWN)
+
+
+class TestEnum(unittest.TestCase):
+    def test_enum_1(self):
+        with db_session:
+            query = select(test for test in Test if test.result == Result.SUCCESS)
+            self.assertEqual(1, query.count())
+            self.assertEqual(query.first().result, Result.SUCCESS)
+
+    def test_enum_2(self):
+        with db_session:
+            query = select(test for test in Test)
+            query = query.filter(lambda test: test.result == Result.FAILURE)
+            self.assertEqual(1, query.count())
+            self.assertEqual(query.first().result, Result.FAILURE)
+
+    def test_enum_3(self):
+        with db_session:
+            query = select(test for test in Test)
+            query = query.where('test.result == Result.UNKNOWN')
+            self.assertEqual(1, query.count())
+            self.assertEqual(query.first().result, Result.UNKNOWN)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,8 @@ if __name__ == "__main__":
         print(s % (name, version, sys.version.split(' ', 1)[0]))
         sys.exit(1)
 
+    deps = ['enum34'] if pv in ((2, 7), (3, 3)) else []
+
     setup(
         name=name,
         version=version,
@@ -124,5 +126,6 @@ if __name__ == "__main__":
         packages=packages,
         package_data=package_data,
         download_url=download_url,
-        test_suite='setup.test_suite'
+        test_suite='setup.test_suite',
+        install_requires=deps
     )


### PR DESCRIPTION
Added an enum converter that creates a text column in the db.

Added Enum type support so query syntax (select/filter/where) can be used and a unittest (test_enum.py) that demonstrates each.

To support Enum in python 2.7 and 3.3 I've changed setup.py to conditionally add a dependency on pypi enum34.