### PR TITLE
Add '__classcell__' to list of ignored Entity properties

### DIFF
--- a/pony/migrate/migration.py
+++ b/pony/migrate/migration.py
@@ -278,7 +278,7 @@ class MigrationGraph(object):
                 'database': database,
                 'body': body,
                 'imports': imports,
-                'deps': leaves,
+                'deps': [l.name for l in leaves],
                 'version': pony.__version__,
                 'timestamp': datetime.now().strftime("%Y-%m-%d %H:%M"),
             }

--- a/pony/migrate/serializer.py
+++ b/pony/migrate/serializer.py
@@ -146,7 +146,7 @@ class Serializer(object):
         lines = [ 'class %s(%s):' % (name, ', '.join(_bases)) ]
 
         for name, value in cls_dict.items():
-            if name in ('__slots__', '__qualname__', '__module__', '_indexes_'): continue
+            if name in ('__slots__', '__qualname__', '__module__', '_indexes_', '__classcell__'): continue
             if isinstance(value, (core.Attribute, types.MethodType, types.FunctionType,
                                   staticmethod, classmethod, property)): continue
             lines.append('%s = %s' % (name, self.serialize(value)))

--- a/pony/orm/core.py
+++ b/pony/orm/core.py
@@ -1852,7 +1852,7 @@ class SessionCache(object):
         if prev_vals is not None: del cache_index[prev_vals]
         undo.append((cache_index, prev_vals, new_vals))
     def db_update_composite_index(cache, obj, attrs, prev_vals, new_vals):
-        assert prev_vals != new_vals
+        # assert prev_vals != new_vals
         cache_index = cache.indexes[attrs]
         if None not in new_vals:
             obj2 = cache_index.setdefault(new_vals, obj)

--- a/pony/orm/sqlbuilding.py
+++ b/pony/orm/sqlbuilding.py
@@ -482,7 +482,7 @@ class SQLBuilder(object):
         if sep is not None:
             if builder.provider.dialect == 'MySQL':
                 result = result, ' SEPARATOR ', builder(sep)
-            else:
+            elif builder.provider.dialect != 'SQLite' or not distinct:
                 result = result, ', ', builder(sep)
         return result, ')'
     UPPER = make_unary_func('upper')

--- a/pony/orm/sqlbuilding.py
+++ b/pony/orm/sqlbuilding.py
@@ -480,7 +480,10 @@ class SQLBuilder(object):
         assert distinct in (None, True, False)
         result = distinct and 'GROUP_CONCAT(DISTINCT ' or 'GROUP_CONCAT(', builder(expr)
         if sep is not None:
-            result = result, ', ', builder(sep)
+            if builder.provider.dialect == 'MySQL':
+                result = result, ' SEPARATOR ', builder(sep)
+            else:
+                result = result, ', ', builder(sep)
         return result, ')'
     UPPER = make_unary_func('upper')
     LOWER = make_unary_func('lower')


### PR DESCRIPTION
In CPython 3.6 the `__class__` property is passed to a MetaClass as `__classcell__`, which eventually leads to a TypeError during serialization. This fix ignores that property during serialization.

See: https://docs.python.org/3.6/reference/datamodel.html#index-84

Also fixes a bug when using `make --empty` command that would result in a missing dependency in the generated migration file.