### PR TITLE
Include LICENSE in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include pony/orm/tests/queries.txt
 include pony/flask/example/templates *.html
+include LICENSE


### PR DESCRIPTION
The Apache license (section 4) requires the license and copyright be redistributed with copies of the work.