### PR TITLE
Fix writer of migrations to allow removing related entities

### DIFF
--- a/pony/migrate/writer.py
+++ b/pony/migrate/writer.py
@@ -248,7 +248,7 @@ class MigrationWriter(object):
                 attr = None
                 if entity:
                     attr = entity._adict_.get(prev_attr.reverse.name)
-                    if attr.entity is not entity: assert False, 'Not implemented'
+                    if attr and attr.entity is not entity: assert False, 'Not implemented'
                     if attr and not attr.reverse:
                         attr = None
                 if attr:


### PR DESCRIPTION
Migration routine made me little confused.
Firstly, I constructed entities:
```python
class User(db.Entity):
    name = Required(str)
    password = Optional(str)
    salt = Optional(str)
    apikeys = Set('APIKey')

class APIKey(db.Entity):
    user = Required(User)
    login = Required(str)
    password = Required(str)
    apikey = Required(str)
```
then I changed my mind to get rid of redundant entity:
```python
class User(db.Entity):
    name = Required(str)
    password = Optional(str)
    salt = Optional(str)

    m_login = Required(str)
    m_password = Required(str)
    m_apikey = Required(str)
```
`manage make` command interrupted with error:
`AssertionError: Not implemented` at `writer.py` line 251
After a brief investigation of code I came to that obvious patch.
Here it is.