### PR TITLE
Fix #470 'imp' module PendingDeprecationWarning

### DIFF
--- a/pony/thirdparty/compiler/pycodegen.py
+++ b/pony/thirdparty/compiler/pycodegen.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function
 from pony.py23compat import izip
 
-import imp
 import os
 import marshal
 import struct
@@ -123,7 +122,12 @@ class Module(AbstractCompileMode):
         f.write(self.getPycHeader())
         marshal.dump(self.code, f)
 
-    MAGIC = imp.get_magic()
+    if VERSION < 3:
+        import imp
+        MAGIC = imp.get_magic()
+    else:
+        import importlib.util
+        MAGIC = importlib.util.MAGIC_NUMBER
 
     def getPycHeader(self):
         # compile.c uses marshal to write a long directly, with


### PR DESCRIPTION
The package 'imp' will be deprecated in favor of importlib. This change allows to use 'importlib' when python version is greater than 2 or use 'imp' otherwise.