### PR TITLE
Support Python 3.9

### DIFF
--- a/pony/orm/decompiling.py
+++ b/pony/orm/decompiling.py
@@ -322,6 +322,20 @@ class Decompiler(object):
         method = pop()
         return ast.CallFunc(method, args)
 
+    def IS_OP(decompiler, invert):
+        oper2 = decompiler.stack.pop()
+        oper1 = decompiler.stack.pop()
+        # invert is set to 1 if operation performs "is not"
+        # https://docs.python.org/3/library/dis.html#opcode-IS_OP
+        return ast.Compare(oper1, [('is not' if invert else 'is', oper2)])
+
+    def CONTAINS_OP(decompiler, invert):
+        oper2 = decompiler.stack.pop()
+        oper1 = decompiler.stack.pop()
+        # invert is set to 1 if operation performs "not in"
+        # https://docs.python.org/3/library/dis.html#opcode-CONTAINS_OP
+        return ast.Compare(oper1, [('not in' if invert else 'in', oper2)])
+
     def COMPARE_OP(decompiler, op):
         oper2 = decompiler.stack.pop()
         oper1 = decompiler.stack.pop()

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Software Development :: Libraries',
     'Topic :: Database'
@@ -106,8 +107,8 @@ download_url = "http://pypi.python.org/pypi/pony/"
 
 if __name__ == "__main__":
     pv = sys.version_info[:2]
-    if pv not in ((2, 7), (3, 3), (3, 4), (3, 5), (3, 6), (3, 7), (3, 8)):
-        s = "Sorry, but %s %s requires Python of one of the following versions: 2.7, 3.3-3.8." \
+    if pv not in ((2, 7), (3, 3), (3, 4), (3, 5), (3, 6), (3, 7), (3, 8), (3, 9)):
+        s = "Sorry, but %s %s requires Python of one of the following versions: 2.7, 3.3-3.9." \
             " You have version %s"
         print(s % (name, version, sys.version.split(' ', 1)[0]))
         sys.exit(1)


### PR DESCRIPTION
Expand the list of supported versions of Python to include newly released Python 3.9.

Resolves #514.
Resolves #530.
Resolves #562.