### PR TITLE
Fix KeyError: NOT_LOADED

### DIFF
--- a/pony/orm/core.py
+++ b/pony/orm/core.py
@@ -2066,7 +2066,8 @@ class SessionCache(object):
             obj2 = cache_index.setdefault(new_val, obj)
             if obj2 is not obj: throw(CacheIndexError, 'Cannot update %s.%s: %s with key %s already exists'
                                                  % (obj.__class__.__name__, attr.name, obj2, new_val))
-        if old_val is not None: del cache_index[old_val]
+        if old_val is not None and old_val is not NOT_LOADED:
+            del cache_index[old_val]
         undo.append((cache_index, old_val, new_val))
     def db_update_simple_index(cache, obj, attr, old_dbval, new_dbval):
         if old_dbval == new_dbval: return


### PR DESCRIPTION
Fix bug with a unique=True field.
When I tried to change unique field of entity, got error:
Traceback (most recent call last):
  File "/home/ivan.zhitnikov/.conda/envs/bp/lib/python3.8/site-packages/pony/orm/core.py", line 2476, in __set__
    cache.update_simple_index(obj, attr, old_val, new_val, undo)
  File "/home/ivan.zhitnikov/.conda/envs/bp/lib/python3.8/site-packages/pony/orm/core.py", line 2069, in update_simple_index
    if old_val is not None: del cache_index[old_val]
KeyError: NOT_LOADED