### PR TITLE
Use a clearly synthetic filename when compiling code #593

### DIFF
--- a/pony/orm/asttranslation.py
+++ b/pony/orm/asttranslation.py
@@ -365,7 +365,8 @@ def create_extractors(code_key, tree, globals, locals, special_functions, const_
                 def extractor(globals, locals):
                     return locals['.0']
             else:
-                code = compile(src, src, 'eval')
+                filename = '<pony ' + src + '>'
+                code = compile(src, filename, 'eval')
                 def extractor(globals, locals, code=code):
                     return eval(code, globals, locals)
             extractors[src] = extractor


### PR DESCRIPTION
Using just the source as the file name confuses tools like coverage.py
that analyze code execution.  Using angle brackets makes clear that this
is not a real file.