### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,10 @@ author = ', '.join([
 ])
 author_email = "team@ponyorm.com"
 url = "https://ponyorm.com"
+project_urls = {
+    "Documentation": "https://docs.ponyorm.org",
+    "Source": "https://github.com/ponyorm/pony",
+}
 licence = "Apache License Version 2.0"
 
 packages = [
@@ -121,6 +125,7 @@ if __name__ == "__main__":
         author=author,
         author_email=author_email,
         url=url,
+        project_urls=project_urls,
         license=licence,
         packages=packages,
         package_data=package_data,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)