### PR TITLE
raise instead of falling through on unknown desc arg

### DIFF
--- a/pony/orm/core.py
+++ b/pony/orm/core.py
@@ -5610,7 +5610,7 @@ def desc(expr):
         return -expr
     if isinstance(expr, str):
         return 'desc(%s)' % expr
-    return expr
+    raise ValueError(f"Not able to sort by unknown expression type {expr}")
 
 def extract_vars(code_key, filter_num, extractors, globals, locals, cells=None):
     if cells:


### PR DESCRIPTION
Raising instead of returning the original value is much safer and gives users the ability to know when the arg passed to `desc` is not handled, instead of silently ignoring the intent.

Fix for: https://github.com/ponyorm/pony/issues/646