### PR TITLE
Prevent a Session from being closed multiple times

### DIFF
--- a/pony/orm/tests/test_declarative_exceptions.py
+++ b/pony/orm/tests/test_declarative_exceptions.py
@@ -153,9 +153,12 @@ class TestSQLTranslatorExceptions(unittest.TestCase):
     @raises_exception(NotImplementedError, "date(s.id, 1, 1)")
     def test30(self):
         select(s for s in Student if s.dob < date(s.id, 1, 1))
-    @raises_exception(ExprEvalError, "`max()` raises TypeError: max() expects at least one argument" if PYPY else
-                                     "`max()` raises TypeError: max expected 1 arguments, got 0" if sys.version_info[:2] < (3, 8) else
-                                     "`max()` raises TypeError: max expected 1 argument, got 0")
+    @raises_exception(
+        ExprEvalError,
+        "`max()` raises TypeError: max() expects at least one argument" if PYPY else
+        "`max()` raises TypeError: max expected 1 arguments, got 0" if sys.version_info[:2] < (3, 8) else
+        "`max()` raises TypeError: max expected 1 argument, got 0" if sys.version_info[:2] < (3, 9) else
+        "`max()` raises TypeError: max expected at least 1 argument, got 0")
     def test31(self):
         select(s for s in Student if s.id < max())
     @raises_exception(TypeError, "Incomparable types 'Student' and 'Course' in expression: s in s.courses")

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ download_url = "http://pypi.python.org/pypi/pony/"
 
 if __name__ == "__main__":
     pv = sys.version_info[:2]
-    if pv not in ((2, 7), (3, 3), (3, 4), (3, 5), (3, 6), (3, 7), (3, 8)):
+    if pv not in ((2, 7), (3, 3), (3, 4), (3, 5), (3, 6), (3, 7), (3, 8), (3, 9)):
         s = "Sorry, but %s %s requires Python of one of the following versions: 2.7, 3.3-3.8." \
             " You have version %s"
         print(s % (name, version, sys.version.split(' ', 1)[0]))

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ if __name__ == "__main__":
         s = "Sorry, but %s %s requires Python of one of the following versions: 2.7, 3.3-3.8." \
             " You have version %s"
         print(s % (name, version, sys.version.split(' ', 1)[0]))
-        sys.exit(1)
 
     REQUIRES = ['docopt']
 


### PR DESCRIPTION
Currently, the Flask API does not work correctly with the Flask.test_client() method when used multiple times.

The reason for that is that due to the teardown hook added in pony/flask/__init__.py gets called after each time the test_client  gets __exited__. However, the db_session got closed before already after the request, leading to two calls to session.__exit__(). This in turn will force the local context counter to go negative, so that the next call will fail with assert not context_counter...
