### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bugfixes
 
-* Fixes #628: DBAPIProvider.__init__() got multiple values for argument 'database' 
+* Fixes #628: DBAPIProvider.__init__() got multiple values for argument 'database'
 
 
 # PonyORM release 0.7.15 (2022-01-27)
@@ -10,7 +10,7 @@
 ## Features
 
 * Add Python 3.10 support, drop support of Python < 3.6
-* You can create an in-memory SQLite database accessible from multiple threads by specifying ":sharedmemory:" as a file name 
+* You can create an in-memory SQLite database accessible from multiple threads by specifying ":sharedmemory:" as a file name
 
 ## Bugfixes
 
@@ -132,7 +132,7 @@ This release contains no new features or bugfixes. The only reason for this rele
 
 * Support of Entity.select(**kwargs)
 * Support of SKIP LOCKED option in 'SELECT ... FOR UPDATE'
-* New function make_proxy(obj) to make cros-db_session proxy objects
+* New function make_proxy(obj) to make cross-db_session proxy objects
 * Specify ON DELETE CASCADE/SET NULL in foreign keys
 * Support of LIMIT in `SELECT FROM (SELECT ...)` type of queries
 * Support for negative JSON array indexes in SQLite
@@ -140,7 +140,7 @@ This release contains no new features or bugfixes. The only reason for this rele
 ## Improvements
 
 * Improved query prefetching: use fewer number of SQL queries
-* Memory optimization: deduplication of values recieved from the database in the same session
+* Memory optimization: deduplication of values received from the database in the same session
 * increase DBAPIProvider.max_params_count value
 
 ## Bugfixes
@@ -289,7 +289,7 @@ This release contains no new features or bugfixes. The only reason for this rele
 * Fixes #283: Lost Json update immediately after object creation
 * Fixes #284: `query.order_by()` orders Json numbers like strings
 * Fixes #288: Expression text parsing issue in Python 3
-* Fixes #293: translation of if-expressions in expression 
+* Fixes #293: translation of if-expressions in expression
 * Fixes #294: Real stack traces swallowed within IPython shell
 * `Collection.count()` method should check if session is alive
 * Set `obj._session_cache_` to None after exiting from db session for better garbage collection
@@ -582,7 +582,7 @@ This release fixes the setup.py problem that was found after the previous releas
 
 # Pony ORM Release 0.5.2 (2014-08-11)
 
-This release is a step forward to Python 3 support. While the external API wasn't changed, the internals were significantly refactored to provide forward compatibility with Python 3. 
+This release is a step forward to Python 3 support. While the external API wasn't changed, the internals were significantly refactored to provide forward compatibility with Python 3.
 
 ## Changes/features:
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Pony ORM also has the Entity-Relationship Diagram Editor which is a great tool f
 Documentation
 -------------
 
-Documenation is available at [https://docs.ponyorm.org](https://docs.ponyorm.org)
-The documentation source is avaliable at [https://github.com/ponyorm/pony-doc](https://github.com/ponyorm/pony-doc).
+Documentation is available at [https://docs.ponyorm.org](https://docs.ponyorm.org)
+The documentation source is available at [https://github.com/ponyorm/pony-doc](https://github.com/ponyorm/pony-doc).
 Please create new documentation related issues [here](https://github.com/ponyorm/pony-doc/issues) or make a pull request with your improvements.
 
 

--- a/pony/options.py
+++ b/pony/options.py
@@ -47,7 +47,7 @@ MEMCACHE = None  # Use in-process python version by default
 ALTERNATIVE_SESSION_MEMCACHE = None     # Use general memcache connection by default
 ALTERNATIVE_ORM_MEMCACHE = None         # Use general memcache connection by default
 ALTERNATIVE_TEMPLATING_MEMCACHE = None  # Use general memcache connection by default
-ALTERNATIVE_RESPONCE_MEMCACHE = None    # Use general memcache connection by default
+ALTERNATIVE_RESPONSE_MEMCACHE = None    # Use general memcache connection by default
 
 # pickle options:
 PICKLE_START_OFFSET = 230

--- a/pony/orm/core.py
+++ b/pony/orm/core.py
@@ -204,7 +204,7 @@ class OptimizationFailed(PonyInternalException):
 
 class UseAnotherTranslator(PonyInternalException):
     def __init__(self, translator):
-        Exception.__init__(self, 'This exception should be catched internally by PonyORM')
+        Exception.__init__(self, 'This exception should be caught internally by PonyORM')
         self.translator = translator
 
 class PonyRuntimeWarning(RuntimeWarning):
@@ -4195,7 +4195,7 @@ class EntityMeta(type):
                     'Column %s does not belong to entity %s' % (cursor.description[i][0], entity.__name__))
         for attr in entity._pk_attrs_:
             if attr not in attr_offsets: throw(ValueError,
-                'Primary key attribue %s was not found in query result set' % attr)
+                'Primary key attribute %s was not found in query result set' % attr)
 
         objects = entity._fetch_objects(cursor, attr_offsets, max_fetch_count)
         return objects
@@ -6047,7 +6047,7 @@ class Query(object):
             func_id = id(func.__code__)
             func_ast, external_names, cells = decompile(func)
         elif not order_by: throw(TypeError,
-            'Argument of filter() method must be a lambda functon or its text. Got: %r' % func)
+            'Argument of filter() method must be a lambda function or its text. Got: %r' % func)
         else: assert False  # pragma: no cover
 
         if argnames:

--- a/pony/orm/dbproviders/oracle.py
+++ b/pony/orm/dbproviders/oracle.py
@@ -319,7 +319,7 @@ class OraIntConverter(dbapiprovider.IntConverter):
             throw(TypeError, "Parameter 'sequence_name' can be used only for PrimaryKey attributes with auto=True")
 
 class OraRealConverter(dbapiprovider.RealConverter):
-    # Note that Oracle has differnet representation of float numbers
+    # Note that Oracle has different representation of float numbers
     def sql_type(converter):
         return 'NUMBER'
 

--- a/pony/orm/tests/test_hybrid_methods_and_properties.py
+++ b/pony/orm/tests/test_hybrid_methods_and_properties.py
@@ -198,7 +198,7 @@ class TestHybridsAndProperties(unittest.TestCase):
 
     @db_session
     def test15(self):
-        # Test repeated use of the same generator with hybrid method/property that uses funciton from external scope
+        # Test repeated use of the same generator with hybrid method/property that uses function from external scope
         result = Person.find_by_full_name('Alexander Kozlovsky')
         self.assertEqual(set(obj.last_name for obj in result), {'Kozlovsky'})
         result = Person.find_by_full_name('Alexander Kozlovsky')

--- a/pony/orm/tests/test_prefetching.py
+++ b/pony/orm/tests/test_prefetching.py
@@ -42,7 +42,7 @@ class TestPrefetching(unittest.TestCase):
         setup_database(db)
         with db_session:
             g1 = Group(number=1, major='Math')
-            g2 = Group(number=2, major='Computer Sciense')
+            g2 = Group(number=2, major='Computer Science')
             c1 = Course(name='Math')
             c2 = Course(name='Physics')
             c3 = Course(name='Computer Science')

--- a/pony/orm/tests/test_raw_sql.py
+++ b/pony/orm/tests/test_raw_sql.py
@@ -95,7 +95,7 @@ class TestRawSQL(unittest.TestCase):
 
     @db_session
     def test_10(self):
-        # raw_sql does not know result type and cannot appy correct type converter automatically
+        # raw_sql does not know result type and cannot apply correct type converter automatically
         dates = select(raw_sql('(p.dob)') for p in Person).order_by(lambda: p.id)[:]
         self.assertEqual(dates, ['1985-01-01', '1983-05-20', '1995-02-15'])
 


### PR DESCRIPTION
Found via `codespell -S .mypy_cache -L te`