### PR TITLE
include code object id into extractors cache key

### DIFF
--- a/pony/orm/sqltranslation.py
+++ b/pony/orm/sqltranslation.py
@@ -10,7 +10,7 @@ from functools import update_wrapper
 from uuid import UUID
 
 from pony import options, utils
-from pony.utils import localbase, is_ident, throw, reraise, copy_ast, between, concat, coalesce
+from pony.utils import localbase, is_ident, throw, reraise, copy_ast, between, concat, coalesce, HashableDict
 from pony.orm.asttranslation import ASTTranslator, ast2src, TranslationError, create_extractors, get_child_nodes
 from pony.orm.decompiling import decompile, DecompileError, operator_mapping
 from pony.orm.ormtypes import \
@@ -2657,7 +2657,7 @@ class HybridFuncMonad(Monad):
         name_mapping = inspect.getcallargs(monad.func, *(monad.params + args), **kwargs)
 
         func = monad.func
-        func_id = id(func)
+        func_id = HashableDict(code=id(func.__code__), func=id(func))
         try:
             func_ast, external_names, cells = decompile(func)
         except DecompileError:


### PR DESCRIPTION
When caching function's extractors use more stable key into the extractors_cache.

The id() of function object is not nessesary unique, as CPython may re-use same memory in case function object is un-referenced. This situation happens when Database objects are dynamically created and destored in the same process.

If a new different function object function is instantiated at the old address, we'll get wrong entry from extractors_cache.

The function's _code object_ id() is more stable. By including code object id() into the cache key this issue is solved.

Solves: https://github.com/ponyorm/pony/issues/675