### PR TITLE
0.7.16.post1

### DIFF
--- a/pony/__init__.py
+++ b/pony/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function
 import os, sys
 from os.path import dirname
 
-__version__ = '0.7.16'
+__version__ = 'p0.7.16'
 
 def detect_mode():
     try: import google.appengine

--- a/pony/orm/asttranslation.py
+++ b/pony/orm/asttranslation.py
@@ -458,5 +458,5 @@ def create_extractors(code_key, tree, globals, locals, special_functions, const_
                 def extractor(globals, locals, code=code):
                     return eval(code, globals, locals)
             extractors[src] = extractor
-        result = extractors_cache[code_key] = tree, extractors
+        result = tree, extractors
     return result

--- a/pony/orm/dbapiprovider.py
+++ b/pony/orm/dbapiprovider.py
@@ -362,6 +362,8 @@ class Pool(localbase):
         except:
             pool.drop(con)
             raise
+        else:
+            pool.drop(con)
     def drop(pool, con):
         assert con is pool.con, (con, pool.con)
         pool.con = None

--- a/pony/orm/sqltranslation.py
+++ b/pony/orm/sqltranslation.py
@@ -672,9 +672,7 @@ class SQLTranslator(ASTTranslator):
                           aggr_func_name=None, aggr_func_distinct=None, sep=None,
                           for_update=False, nowait=False, skip_locked=False, is_not_null_checks=False):
         attr_offsets = None
-        if distinct is None:
-            if not translator.order:
-                distinct = translator.distinct
+        if distinct is None: distinct = translator.distinct
         ast_transformer = lambda ast: ast
         if for_update:
             sql_ast = [ 'SELECT_FOR_UPDATE', nowait, skip_locked ]

--- a/pony/utils/utils.py
+++ b/pony/utils/utils.py
@@ -16,8 +16,7 @@ from pony import options
 
 from pony.thirdparty.decorator import decorator as _decorator
 
-if pony.MODE.startswith('GAE-'): localbase = object
-else: from threading import local as localbase
+from threading import local as localbase
 
 
 class PonyDeprecationWarning(DeprecationWarning):


### PR DESCRIPTION
match pep 440 naming: https://peps.python.org/pep-0440/

```
Collecting pony
  Cloning https://github.com/workstep/pony.git (to revision p0.7.16) to /private/var/folders/l6/lc9mmjwx1_ddmtzbg1y3crmr0000gn/T/pip-install-7dcm9c7x/pony_53e513034bcd471d868a93f2a9bbc460
  Running command git clone --filter=blob:none --quiet https://github.com/workstep/pony.git /private/var/folders/l6/lc9mmjwx1_ddmtzbg1y3crmr0000gn/T/pip-install-7dcm9c7x/pony_53e513034bcd471d868a93f2a9bbc460
  Running command git checkout -b p0.7.16 --track origin/p0.7.16
  Switched to a new branch 'p0.7.16'
  branch 'p0.7.16' set up to track 'origin/p0.7.16'.
  Resolved https://github.com/workstep/pony.git to commit 2b4e286113cadc8173cb3f324eb340b7ba2b51ad
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [27 lines of output]
      /opt/homebrew/lib/python3.10/site-packages/setuptools/dist.py:548: UserWarning: The version specified ('p0.7.16') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
        warnings.warn(
      running egg_info
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/l6/lc9mmjwx1_ddmtzbg1y3crmr0000gn/T/pip-install-7dcm9c7x/pony_53e513034bcd471d868a93f2a9bbc460/setup.py", line 115, in <module>
          setup(
        File "/opt/homebrew/lib/python3.10/site-packages/setuptools/__init__.py", line 108, in setup
          return distutils.core.setup(**attrs)
        File "/opt/homebrew/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
        File "/opt/homebrew/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/opt/homebrew/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/opt/homebrew/lib/python3.10/site-packages/setuptools/dist.py", line 1213, in run_command
          super().run_command(command)
        File "/opt/homebrew/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 987, in run_command
          cmd_obj.ensure_finalized()
        File "/opt/homebrew/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 111, in ensure_finalized
          self.finalize_options()
        File "/opt/homebrew/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 219, in finalize_options
          parsed_version = parse_version(self.egg_version)
        File "/opt/homebrew/lib/python3.10/site-packages/pkg_resources/_vendor/packaging/version.py", line 197, in __init__
          raise InvalidVersion(f"Invalid version: '{version}'")
      pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: 'p0.7.16'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```