### PR TITLE
orm/core: do not add "missing" select to query starting with "with"

### DIFF
--- a/pony/orm/core.py
+++ b/pony/orm/core.py
@@ -404,7 +404,7 @@ def rollback():
     finally:
         del exceptions
 
-select_re = re.compile(r'\s*select\b', re.IGNORECASE)
+select_re = re.compile(r'\s*(select|with)\b', re.IGNORECASE)
 
 class DBSessionContextManager(object):
     __slots__ = 'retry', 'retry_exceptions', 'allowed_exceptions', \

--- a/pony/orm/core.py
+++ b/pony/orm/core.py
@@ -3676,7 +3676,6 @@ class EntityIter(object):
 entity_id_counter = itertools.count(1)
 new_instance_id_counter = itertools.count(1)
 
-select_re = re.compile(r'select\b', re.IGNORECASE)
 lambda_re = re.compile(r'lambda\b')
 
 class EntityMeta(type):


### PR DESCRIPTION
- `WTIH … SELECT` is a valid query (at least for MariaDB, see CTE)
- as I know, `SELECT WITH …` is always invalid, hence adding `SELECT` does not improve anything
- btw: removed duplicated definition of select_re in same file