### PR TITLE
Mention that PonyORM works with MariaDB as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here is an example query in Pony:
 select(p for p in Product if p.name.startswith('A') and p.cost <= 1000)
 ```
 
-Pony translates queries to SQL using a specific database dialect. Currently Pony works with SQLite, MySQL, PostgreSQL and Oracle databases.
+Pony translates queries to SQL using a specific database dialect. Currently Pony works with SQLite, MySQL, MariaDB, PostgreSQL and Oracle databases.
 
 By providing a Pythonic API, Pony facilitates fast app development. Pony is an easy-to-learn and easy-to-use library. It makes your work more productive and helps to save resources. Pony achieves this ease of use through the following:
 


### PR DESCRIPTION
Because MySQL and MariaDB use the same on-the-wire protocol and most SQL-level features are identical, PonyORM also works with MariaDB, using the MySQL provider.

Tested on MariaDB 10.6.14.

After creating a 'test' database, and a user 'whoever' with access to that database (`GRANT ALL PRIVILEGES ON test.* TO whoever`), the "first steps" from https://docs.ponyorm.org/firststeps.html work fine, e.g.:

```py
    from pony.orm import *
    db=Database()
    class Person(db.Entity):
        name=Required(str)
        age=Required(int)
    db.bind(provider='mysql', user='whoever', password='foobar', db='test')
    db.generate_mapping(create_tables=True)
```