### PR TITLE
Add support for Python 3.12

### DIFF
--- a/pony/py23compat.py
+++ b/pony/py23compat.py
@@ -7,6 +7,7 @@ PY38 = sys.version_info[:2] >= (3, 8)
 PY39 = sys.version_info[:2] >= (3, 9)
 PY310 = sys.version_info[:2] >= (3, 10)
 PY311 = sys.version_info[:2] >= (3, 11)
+PY312 = sys.version_info[:2] >= (3, 12)
 
 unicode = str
 buffer = bytes

--- a/setup.py
+++ b/setup.py
@@ -109,8 +109,8 @@ download_url = "http://pypi.python.org/pypi/pony/"
 
 if __name__ == "__main__":
     pv = sys.version_info[:2]
-    if pv not in ((3, 8), (3, 9), (3, 10), (3, 11)):
-        s = "Sorry, but %s %s requires Python of one of the following versions: 3.8-3.11." \
+    if pv < (3, 8) or pv > (3, 12):
+        s = "Sorry, but %s %s requires Python of one of the following versions: 3.8-3.12." \
             " You have version %s"
         print(s % (name, version, sys.version.split(' ', 1)[0]))
         sys.exit(1)


### PR DESCRIPTION
Py 3.12 changes how yield loops are generated and I didn't want to rework how jump analysis works, so the change detects the new jump combination and "inserts" the old one.
See comment in `Decompiler.get_instructions`.

Everything else was mostly straight forward.

Tested with 3.8.19, 3.9.19, 3.10.14, 3.11.9, 3.12.3
and get the same test results for all of them `run=3870 errors=1 failures=17`.
All failures are in `pony.orm.tests.test_json.TestJson` and also happen on main for me.
