### PR TITLE
CI: run unittests

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,0 +1,40 @@
+name: unittests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  unittest:
+    runs-on: ${{ matrix.os }}
+    name: Test Python ${{ matrix.python.version }} ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        python:
+          - {version: '3.8'}
+          - {version: '3.9'}
+          - {version: '3.10'}
+          - {version: '3.11'}
+          - {version: '3.12'}
+        include:
+          - python: {version: '3.12'}  # latest
+            os: windows-latest
+          - python: {version: '3.12'}  # latest
+            os: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python.version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python.version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip flask
+    - name: Unittests
+      run: |
+        python -m unittest


### PR DESCRIPTION
Adds a simple github action to run unit tests on all supported python versions on push and PR.

Also runs one on Windows and one on macos to check for platform-dependent issues.

If you haven't done so already, you need to enable repository actions in the repository settings.

Example test results can be viewed here: https://github.com/black-sliver/pony/actions/runs/10568480643