### PR TITLE
handle POP_JUMP_IF_NONE, POP_JUMP_IF_NOT_NONE

### DIFF
--- a/pony/orm/decompiling.py
+++ b/pony/orm/decompiling.py
@@ -694,6 +694,12 @@ class Decompiler(object):
     def jump_if_not_none(decompiler, endpos):
         return decompiler.conditional_jump_none_impl(endpos, True)
 
+    def POP_JUMP_IF_NONE(decompiler, endpos):
+        return decompiler.jump_if_none(endpos)
+
+    def POP_JUMP_IF_NOT_NONE(decompiler, endpos):
+        return decompiler.jump_if_not_none(endpos)
+
     def process_target(decompiler, pos, partial=False):
         if pos is None:
             limit = None


### PR DESCRIPTION
fixes issues with POP_JUMP_IF_NONE, and POP_JUMP_IF_NOT_NONE that happen in python 3.12:
- https://github.com/ponyorm/pony/issues/702
- https://github.com/ponyorm/pony/issues/725

previously when queries contain `if _ is None` or `if _ is not None` a decompiling error would be raised

