### PR TITLE
Fix raw string regex patterns

### DIFF
--- a/pony/converting.py
+++ b/pony/converting.py
@@ -1,5 +1,3 @@
-# coding: cp1251
-
 from __future__ import absolute_import, print_function
 
 import re
@@ -107,7 +105,7 @@ date_str_list = [
     r'\D*(?P<year>\d{4})\D+(?P<day>\d{1,2})\D*',
     r'\D*(?P<day>\d{1,2})\D+(?P<year>\d{4})\D*'
     ]
-date_re_list = [ re.compile('^%s$'%s, re.UNICODE) for s in date_str_list ]
+date_re_list = [ re.compile(r'^%s$'%s, re.UNICODE) for s in date_str_list ]
 
 time_str = r'''
     (?P<hh>\d{1,2})  # hours
@@ -127,14 +125,14 @@ time_str = r'''
         \s* (?: (?P<am> a\.?m\.? ) | (?P<pm> p\.?m\.? ) )
     )?
 '''
-time_re = re.compile('^%s$'%time_str, re.VERBOSE)
+time_re = re.compile(r'^%s$'%time_str, re.VERBOSE)
 
-datetime_re_list = [ re.compile('^%s(?:[t ]%s)?$' % (date_str, time_str), re.UNICODE | re.VERBOSE)
+datetime_re_list = [ re.compile(r'^%s(?:[t ]%s)?$' % (date_str, time_str), re.UNICODE | re.VERBOSE)
                      for date_str in date_str_list ]
 
 month_lists = [
     "jan feb mar apr may jun jul aug sep oct nov dec".split(),
-    u"янв фев мар апр май июн июл авг сен окт ноя дек".split(),  # Russian
+    u"СЏРЅРІ С„РµРІ РјР°СЂ Р°РїСЂ РјР°Р№ РёСЋРЅ РёСЋР» Р°РІРі СЃРµРЅ РѕРєС‚ РЅРѕСЏ РґРµРє".split(),  # Russian
     ]
 month_dict = {}
 
@@ -142,7 +140,7 @@ for month_list in month_lists:
     for i, month in enumerate(month_list):
         month_dict[month] = i + 1
 
-month_dict[u'мая'] = 5  # Russian
+month_dict[u'РјР°СЏ'] = 5  # Russian
 
 def str2date(s):
     s = s.strip().lower()

--- a/pony/orm/dbapiprovider.py
+++ b/pony/orm/dbapiprovider.py
@@ -88,7 +88,7 @@ def unexpected_args(attr, args):
         len(args) > 1 and 's' or '', attr, ', '.join(repr(arg) for arg in args))
     )
 
-version_re = re.compile('[0-9\.]+')
+version_re = re.compile(r'[0-9\.]+')
 
 def get_version_tuple(s):
     m = version_re.match(s)

--- a/pony/orm/dbproviders/oracle.py
+++ b/pony/orm/dbproviders/oracle.py
@@ -282,7 +282,7 @@ class OraBuilder(SQLBuilder):
             result = result, ", ','"
         return result, ') WITHIN GROUP(ORDER BY 1)'
 
-json_item_re = re.compile('[\w\s]*')
+json_item_re = re.compile(r'[\w\s]*')
 
 
 class OraBoolConverter(dbapiprovider.BoolConverter):

--- a/pony/thirdparty/decorator.py
+++ b/pony/thirdparty/decorator.py
@@ -59,7 +59,7 @@ else:
     def get_init(cls):
         return cls.__init__.im_func
 
-DEF = re.compile('\s*def\s*([_\w][_\w\d]*)\s*\(')
+DEF = re.compile(r'\s*def\s*([_\w][_\w\d]*)\s*\(')
 
 # basic functionality
 class FunctionMaker(object):


### PR DESCRIPTION
Fix raw string regex patterns and update `converting.py` encoding

This PR addresses #693 which is generating a fair amount of logging spam when I'm using Pony.

## Context

Python 3.12 changed the way escape sequences in strings work with regular expressions. From the [Python 3.12 changelog](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes):

> A SyntaxWarning is now emitted for invalid escape sequences in regular expressions passed as strings. The warning will be enabled by default in Python 3.14. Use raw strings (r"...") for regular expressions containing backslashes.

## Changes

Added 'r' prefix to regex patterns in:
- `pony/orm/dbproviders/oracle.py`: `json_item_re`
- `pony/orm/dbapiprovider.py`: `version_re`
- `pony/thirdparty/decorator.py`: `DEF`
- `pony/converting.py`: `date_re_list`, `time_re`, `datetime_re_list`

Note: `email_re` and `rfc2822_email_re` in `converting.py` already had the 'r' prefix.

Additionally, `converting.py` was converted from cp1251 to UTF-8 encoding using:
```bash
iconv -f cp1251 -t utf-8 pony/converting.py > pony/converting.py.utf8
mv pony/converting.py.utf8 pony/converting.py
```
This encoding change aligns with a similar change made in #669.

## Why

Using raw strings for regex patterns is a Python best practice because:
1. It avoids double escaping of backslashes
2. Makes patterns more readable and less error-prone
3. Prevents potential issues with string escape sequences interfering with regex syntax
4. Eliminates SyntaxWarnings in Python 3.12+ for invalid escape sequences

---

This PR was generated with https://www.all-hands.dev/ (an open source agent) but I have reviewed the code changes prior to submitting, noted potential areas for review, and adjusted this description to include additional context.