### PR TITLE
fix: length check in _extract_time_parts

### DIFF
--- a/pony/converting.py
+++ b/pony/converting.py
@@ -192,7 +192,7 @@ def _extract_time_parts(groupdict):
 
     if isinstance(ss, str) and '.' in ss:
         ss, mcs = ss.split('.', 1)
-        if len('mcs') < 6: mcs = (mcs + '000000')[:6]
+        if len(mcs) < 6: mcs = (mcs + '000000')[:6]
     else: mcs = 0
 
     return int(hh), int(mm or 0), int(ss or 0), int(mcs)


### PR DESCRIPTION
I was browsing converting.py and I noticed a check `len('mcs') < 6` which always returns true, it looks like it was supposed to be `len(mcs) < 6`