### PR TITLE
Fix Python 3.12 decompiler bug for multiline generator expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ pony/orm/tests/.coverage
 pony/orm/tests/coverage.bat
 pony/orm/tests/htmlcov/*.*
 MANIFEST
+build/
+dist/
 docs/_build/
 pony.egg-info/

--- a/pony/orm/decompiling.py
+++ b/pony/orm/decompiling.py
@@ -303,7 +303,7 @@ class Decompiler(object):
         # If conditions_end points directly to YIELD_VALUE (multiline bytecode structure
         # where no backward jump precedes yield), skip it - jumps targeting YIELD_VALUE
         # directly are elt-level short-circuits, not filter or-conditions.
-        if i > 0 and decompiler.instructions[i][2] == 'YIELD_VALUE':
+        if decompiler.instructions[i][2] == 'YIELD_VALUE':
             i -= 1
         while i > 0:
             pos, next_pos, opname, arg = decompiler.instructions[i]

--- a/pony/orm/decompiling.py
+++ b/pony/orm/decompiling.py
@@ -278,12 +278,6 @@ class Decompiler(object):
                     decompiler.instructions_map[decompiler.pos] = len(decompiler.instructions)
                     decompiler.instructions.append((decompiler.pos, i, opname, arg))
             if opname == 'YIELD_VALUE':
-                # In Python 3.12+, multiline generator expressions compile to a structure
-                # where the single JUMP_BACKWARD (shared between filter-failure and
-                # post-yield looping) appears *after* YIELD_VALUE, so the pre-yield
-                # backward-jump merge never fires and conditions_end stays 0. Seed it
-                # from the YIELD_VALUE position so analyze_jumps can walk back and
-                # correctly classify filter or-jumps vs. elt-level short-circuits.
                 if decompiler.conditions_end == 0:
                     decompiler.conditions_end = decompiler.pos
                 before_yield = False
@@ -300,9 +294,6 @@ class Decompiler(object):
                         decompiler.conditions_end = y
 
         i = decompiler.instructions_map[decompiler.conditions_end]
-        # If conditions_end points directly to YIELD_VALUE (multiline bytecode structure
-        # where no backward jump precedes yield), skip it - jumps targeting YIELD_VALUE
-        # directly are elt-level short-circuits, not filter or-conditions.
         if decompiler.instructions[i][2] == 'YIELD_VALUE':
             i -= 1
         while i > 0:

--- a/pony/orm/decompiling.py
+++ b/pony/orm/decompiling.py
@@ -278,6 +278,14 @@ class Decompiler(object):
                     decompiler.instructions_map[decompiler.pos] = len(decompiler.instructions)
                     decompiler.instructions.append((decompiler.pos, i, opname, arg))
             if opname == 'YIELD_VALUE':
+                # In Python 3.12+, multiline generator expressions compile to a structure
+                # where the single JUMP_BACKWARD (shared between filter-failure and
+                # post-yield looping) appears *after* YIELD_VALUE, so the pre-yield
+                # backward-jump merge never fires and conditions_end stays 0. Seed it
+                # from the YIELD_VALUE position so analyze_jumps can walk back and
+                # correctly classify filter or-jumps vs. elt-level short-circuits.
+                if decompiler.conditions_end == 0:
+                    decompiler.conditions_end = decompiler.pos
                 before_yield = False
             decompiler.pos = i
     def analyze_jumps(decompiler):
@@ -292,6 +300,11 @@ class Decompiler(object):
                         decompiler.conditions_end = y
 
         i = decompiler.instructions_map[decompiler.conditions_end]
+        # If conditions_end points directly to YIELD_VALUE (multiline bytecode structure
+        # where no backward jump precedes yield), skip it — jumps targeting YIELD_VALUE
+        # directly are elt-level short-circuits, not filter or-conditions.
+        if i > 0 and decompiler.instructions[i][2] == 'YIELD_VALUE':
+            i -= 1
         while i > 0:
             pos, next_pos, opname, arg = decompiler.instructions[i]
             if pos in decompiler.jump_map:

--- a/pony/orm/decompiling.py
+++ b/pony/orm/decompiling.py
@@ -301,7 +301,7 @@ class Decompiler(object):
 
         i = decompiler.instructions_map[decompiler.conditions_end]
         # If conditions_end points directly to YIELD_VALUE (multiline bytecode structure
-        # where no backward jump precedes yield), skip it — jumps targeting YIELD_VALUE
+        # where no backward jump precedes yield), skip it - jumps targeting YIELD_VALUE
         # directly are elt-level short-circuits, not filter or-conditions.
         if i > 0 and decompiler.instructions[i][2] == 'YIELD_VALUE':
             i -= 1

--- a/pony/orm/examples/run_examples.py
+++ b/pony/orm/examples/run_examples.py
@@ -1,0 +1,37 @@
+"""Run all ORM examples to verify they work across Python versions."""
+import subprocess
+import sys
+import os
+import tempfile
+
+EXAMPLES_DIR = os.path.dirname(os.path.abspath(__file__))
+
+EXAMPLES = [
+    'demo.py',
+    'estore.py',
+    'numbers.py',
+    'compositekeys.py',
+    'inheritance1.py',
+    'university1.py',
+    'university2.py',
+]
+
+if __name__ == '__main__':
+    failed = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for example in EXAMPLES:
+            path = os.path.join(EXAMPLES_DIR, example)
+            print(f'Running {example}...', flush=True)
+            # Use -c so the examples dir isn't added to sys.path, which would
+            # cause pony's `import numbers` to find numbers.py (the example)
+            # instead of the stdlib numbers module.
+            script = f"exec(compile(open({repr(path)}).read(), {repr(path)}, 'exec'), {{'__name__': '__main__', '__file__': {repr(path)}}})"
+            result = subprocess.run([sys.executable, '-c', script], cwd=tmpdir)
+            if result.returncode != 0:
+                print(f'FAILED: {example}', file=sys.stderr)
+                failed.append(example)
+
+    if failed:
+        print(f'\n{len(failed)} example(s) failed: {", ".join(failed)}', file=sys.stderr)
+        sys.exit(1)
+    print(f'\nAll {len(EXAMPLES)} examples passed.')

--- a/pony/orm/tests/test_bug_py312_multiline_gen.py
+++ b/pony/orm/tests/test_bug_py312_multiline_gen.py
@@ -1,0 +1,71 @@
+"""
+Regression tests for Python 3.12 decompiler bug with multiline generator expressions.
+
+In Python 3.12, the single JUMP_BACKWARD instruction (shared between "filter failed,
+try next item" and "value yielded, loop back") appears *after* YIELD_VALUE instead of
+before it. Pony's decompiler expected to find that jump before the yield to locate
+the filter boundary. When it wasn't there, an internal counter stayed at 0 and the
+decompiler misclassified or/and short-circuits as filter conditions, crashing on any
+multiline query with a compound filter or or/and in the element expression.
+"""
+import unittest
+
+from pony import orm
+from pony.orm.tests import setup_database, teardown_database
+
+db = orm.Database()
+
+
+class Product(db.Entity):
+    name     = orm.Required(str)
+    price    = orm.Required(float)
+    discount = orm.Optional(float)
+
+
+class TestPy312MultilineGenerator(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        setup_database(db)
+        with orm.db_session:
+            Product(name='Widget',  price=9.99,  discount=0.10)
+            Product(name='Gadget',  price=49.99, discount=None)
+            Product(name='Doohick', price=4.99,  discount=0.05)
+
+    @classmethod
+    def tearDownClass(cls):
+        teardown_database(db)
+
+    def test_multiline_filter_or(self):
+        # Single-line and multiline forms of the same query must return identical results.
+        with orm.db_session:
+            single = set(orm.select(p.name for p in Product if p.discount is not None or p.price < 5.0))
+            multi  = set(orm.select(
+                p.name
+                for p in Product
+                if (p.discount is not None or p.price < 5.0)
+            ))
+        self.assertEqual(single, multi)
+        self.assertEqual(multi, {'Widget', 'Doohick'})
+
+    def test_multiline_filter_and(self):
+        with orm.db_session:
+            single = set(orm.select(p.name for p in Product if p.discount is not None and p.price < 20.0))
+            multi  = set(orm.select(
+                p.name
+                for p in Product
+                if (p.discount is not None and p.price < 20.0)
+            ))
+        self.assertEqual(single, multi)
+        self.assertEqual(multi, {'Widget', 'Doohick'})
+
+    def test_multiline_multi_for_compound_filter(self):
+        with orm.db_session:
+            single = set(orm.select((p.name, q.name) for p in Product for q in Product if p.price < q.price and p.discount is not None))
+            multi  = set(orm.select(
+                (p.name, q.name)
+                for p in Product
+                for q in Product
+                if p.price < q.price and p.discount is not None
+            ))
+        self.assertEqual(single, multi)
+        self.assertEqual(multi, {('Widget', 'Gadget'), ('Doohick', 'Widget'), ('Doohick', 'Gadget')})

--- a/pony/orm/tests/test_decompiler.py
+++ b/pony/orm/tests/test_decompiler.py
@@ -318,7 +318,158 @@ class TestDecompiler(unittest.TestCase):
         self.assertDecompilesTo(re.sub("\n", " ", expr), expected_result)
         self.assertDecompilesTo( expr, expected_result)
 
+    def test_ast_elt_and(self):
+        self.assertDecompilesTo(
+            '(x and y for z in T)',
+            """
+            GeneratorExp(
+              elt=BoolOp(
+                op=And(),
+                values=[
+                  Name(id='x', ctx=Load()),
+                  Name(id='y', ctx=Load())]),
+              generators=[
+                comprehension(
+                  target=Name(id='z', ctx=Store()),
+                  iter=Name(id='.0', ctx=Load()),
+                  ifs=[],
+                  is_async=0)])
+            """)
 
+    def test_ast_elt_or(self):
+        self.assertDecompilesTo(
+            '(x or y for z in T)',
+            """
+            GeneratorExp(
+              elt=BoolOp(
+                op=And(),
+                values=[
+                  UnaryOp(
+                    op=Not(),
+                    operand=Name(id='x', ctx=Load())),
+                  Name(id='y', ctx=Load())]),
+              generators=[
+                comprehension(
+                  target=Name(id='z', ctx=Store()),
+                  iter=Name(id='.0', ctx=Load()),
+                  ifs=[],
+                  is_async=0)])
+            """)
+
+    def test_ast_elt_and_compare(self):
+        self.assertDecompilesTo(
+            '(len(a) == len(b) and a != b for x in T)',
+            """
+            GeneratorExp(
+              elt=BoolOp(
+                op=And(),
+                values=[
+                  Compare(
+                    left=Call(
+                      func=Name(id='len', ctx=Load()),
+                      args=[
+                        Name(id='a', ctx=Load())],
+                      keywords=[]),
+                    ops=[
+                      Eq()],
+                    comparators=[
+                      Call(
+                        func=Name(id='len', ctx=Load()),
+                        args=[
+                          Name(id='b', ctx=Load())],
+                        keywords=[])]),
+                  Compare(
+                    left=Name(id='a', ctx=Load()),
+                    ops=[
+                      NotEq()],
+                    comparators=[
+                      Name(id='b', ctx=Load())])]),
+              generators=[
+                comprehension(
+                  target=Name(id='x', ctx=Store()),
+                  iter=Name(id='.0', ctx=Load()),
+                  ifs=[],
+                  is_async=0)])
+            """)
+
+    def test_ast_no_filter(self):
+        self.assertDecompilesTo(
+            '(x for x in T)',
+            """
+            GeneratorExp(
+              elt=Name(id='x', ctx=Load()),
+              generators=[
+                comprehension(
+                  target=Name(id='x', ctx=Store()),
+                  iter=Name(id='.0', ctx=Load()),
+                  ifs=[],
+                  is_async=0)])
+            """)
+
+    def test_ast_multiline_not_none(self):
+        expr = """(m
+                for m in []
+                if (x is not None or y))"""
+        expected_result = """
+            GeneratorExp(
+              elt=Name(id='m', ctx=Load()),
+              generators=[
+                comprehension(
+                  target=Name(id='m', ctx=Store()),
+                  iter=Name(id='.0', ctx=Load()),
+                  ifs=[
+                    BoolOp(
+                      op=Or(),
+                      values=[
+                        Compare(
+                          left=Name(id='x', ctx=Load()),
+                          ops=[
+                            IsNot()],
+                          comparators=[
+                            Constant(value=None)]),
+                        Name(id='y', ctx=Load())])],
+                  is_async=0)])
+            """
+        self.assertDecompilesTo(re.sub("\n", " ", expr), expected_result)
+        self.assertDecompilesTo(expr, expected_result)
+
+    def test_ast_multiline_multi_for(self):
+        expr = """(m
+                for m in []
+                if x and y and z and j
+                for n in []
+                if x and y and z and j)"""
+        expected_result = """
+            GeneratorExp(
+              elt=Name(id='m', ctx=Load()),
+              generators=[
+                comprehension(
+                  target=Name(id='m', ctx=Store()),
+                  iter=Name(id='.0', ctx=Load()),
+                  ifs=[
+                    BoolOp(
+                      op=And(),
+                      values=[
+                        Name(id='x', ctx=Load()),
+                        Name(id='y', ctx=Load()),
+                        Name(id='z', ctx=Load()),
+                        Name(id='j', ctx=Load())])],
+                  is_async=0),
+                comprehension(
+                  target=Name(id='n', ctx=Store()),
+                  iter=Constant(value=()),
+                  ifs=[
+                    BoolOp(
+                      op=And(),
+                      values=[
+                        Name(id='x', ctx=Load()),
+                        Name(id='y', ctx=Load()),
+                        Name(id='z', ctx=Load()),
+                        Name(id='j', ctx=Load())])],
+                  is_async=0)])
+            """
+        self.assertDecompilesTo(re.sub("\n", " ", expr), expected_result)
+        self.assertDecompilesTo(expr, expected_result)
 
 
 for i, gen in enumerate(generate_gens()):


### PR DESCRIPTION
## Summary
  Python 3.12 changed how multiline generator expressions compile. In 3.11 and earlier, the "filter failed" and "post-yield loop-back" paths each had their own `JUMP_BACKWARD`, and the
  pre-yield one gave the decompiler its filter boundary (`conditions_end`). In 3.12, the multiline form merges these into a single `JUMP_BACKWARD` placed *after* `YIELD_VALUE` — so the
  pre-yield scan found nothing, `conditions_end` stayed 0, and any `or`/`and` in the filter got misclassified as an element-level short-circuit, crashing the translator.

  Two fixes in `decompiling.py`:
  - When `YIELD_VALUE` is reached and `conditions_end` is still 0, seed it from `YIELD_VALUE`'s offset so `analyze_jumps` has a boundary to walk from.
  - Step back one instruction before starting that walk -- element-level `or` short-circuits jump directly to `YIELD_VALUE`, and without this they'd be misread as filter conditions.

  ## Affected queries
  Any multiline generator with a compound filter or boolean element expression raised `TranslationError` on 3.12. Single-line generators were unaffected.

  ```python
  # fine on all versions
  select(p.name for p in Product if p.discount is not None or p.price < 5.0)

  # crashed on 3.12 before this fix
  select(
      p.name
      for p in Product
      if (p.discount is not None or p.price < 5.0)
  )
  ```

  ## Testing
  - `test_bug_py312_multiline_gen.py`: multiline `or`, `and`, and multi-`for` compound filters against a live SQLite database.
  - `test_decompiler.py`: AST-level assertions for single-line vs. multiline parity, element-level boolean expressions, `is None`/`is not None` variants, and a combinatorial suite of nested
  `and`/`or` patterns.