### PR TITLE
add docker test matrix (python versions, database engines)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+build/
+dist/
+*.egg-info/
+__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+.git/
+.tox/
+.venv/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ pony/orm/tests/.coverage
 pony/orm/tests/coverage.bat
 pony/orm/tests/htmlcov/*.*
 MANIFEST
+build/
+dist/
 docs/_build/
 pony.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
+
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir -e . psycopg2-binary pymysql pytest
+
+CMD ["python", "-m", "pytest", "pony/orm/tests/", "-v"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,89 @@
+PYTHON_VERSIONS := 3.8 3.9 3.10 3.11 3.12
+DB_BACKENDS     := sqlite mysql postgres cockroach
+
+# Pin the compose project name so the network is always pony_default.
+export COMPOSE_PROJECT_NAME := pony
+COMPOSE_NETWORK := pony_default
+
+PYTHON      ?= python
+PYTEST_ARGS ?=
+TEST_CMD     = $(PYTHON) -m pytest pony/orm/tests/ -v $(PYTEST_ARGS)
+
+.PHONY: usage test test-all docker-up docker-down clean \
+        $(addprefix test-,$(DB_BACKENDS)) \
+        $(addprefix test-,$(PYTHON_VERSIONS)) \
+        $(foreach v,$(PYTHON_VERSIONS),$(addprefix test-$(v)-,$(DB_BACKENDS)))
+
+usage:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Local targets (host Python, docker-compose DBs on localhost):"
+	@echo "  test-sqlite       SQLite in-memory (no Docker needed)"
+	@echo "  test-mysql        MySQL"
+	@echo "  test-postgres     PostgreSQL"
+	@echo "  test-cockroach    CockroachDB"
+	@echo "  test-all          All local DB backends"
+	@echo ""
+	@echo "Docker targets (containerised Python x docker-compose DBs):"
+	@echo "  test-<version>          All DB backends in Python <version>  (e.g. make test-3.12)"
+	@echo "  test-<version>-<db>     One DB in Python <version>           (e.g. make test-3.12-mysql)"
+	@echo "  test                    Full matrix: all versions x all DBs"
+	@echo ""
+	@echo "Python versions : $(PYTHON_VERSIONS)"
+	@echo "DB backends     : $(DB_BACKENDS)"
+	@echo ""
+	@echo "Infrastructure:"
+	@echo "  docker-up    Start database containers (MySQL, PostgreSQL, CockroachDB)"
+	@echo "  docker-down  Stop and remove database containers"
+	@echo "  clean        Remove all pony-test Docker images"
+
+# Full matrix — -k keeps going past failures so all combinations run
+test:
+	$(MAKE) -k $(addprefix test-,$(PYTHON_VERSIONS))
+
+# Local DB targets
+test-sqlite:
+	$(TEST_CMD)
+
+test-mysql:
+	env pony_test_db="pony/orm/tests/config/mysql.py" $(TEST_CMD)
+
+test-postgres:
+	env pony_test_db="pony/orm/tests/config/postgres.py" $(TEST_CMD)
+
+test-cockroach:
+	env pony_test_db="pony/orm/tests/config/cockroach.py" $(TEST_CMD)
+
+test-all: test-sqlite test-mysql test-postgres test-cockroach
+
+# Docker: test-<version> expands to all DB backends for that version
+$(addprefix test-,$(PYTHON_VERSIONS)): test-%: $(addprefix test-%-,$(DB_BACKENDS))
+
+# Docker: test-<version>-sqlite
+define DOCKER_SQLITE_RULE
+test-$(1)-sqlite:
+	docker build --build-arg PYTHON_VERSION=$(1) -t pony-test-$(1) .
+	docker run --rm pony-test-$(1)
+endef
+$(foreach v,$(PYTHON_VERSIONS),$(eval $(call DOCKER_SQLITE_RULE,$(v))))
+
+# Docker: test-<version>-<db>  (non-sqlite: attach to compose network, pass service hostname)
+define DOCKER_DB_RULE
+test-$(1)-$(2):
+	docker build --build-arg PYTHON_VERSION=$(1) -t pony-test-$(1) .
+	docker run --rm \
+		--network "$(COMPOSE_NETWORK)" \
+		--env pony_test_db="pony/orm/tests/config/$(2).py" \
+		--env PONY_TEST_HOST=$(2) \
+		pony-test-$(1)
+endef
+$(foreach v,$(PYTHON_VERSIONS),$(foreach db,mysql postgres cockroach,$(eval $(call DOCKER_DB_RULE,$(v),$(db)))))
+
+docker-up:
+	docker compose up -d --wait
+
+docker-down:
+	docker compose down -v
+
+clean:
+	@$(foreach v,$(PYTHON_VERSIONS),docker rmi -f pony-test-$(v) 2>/dev/null || true;)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: pony_test
+      MYSQL_USER: ponytest
+      MYSQL_PASSWORD: ponytest
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "ponytest", "-pponytest"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: pony_test
+      POSTGRES_USER: ponytest
+      POSTGRES_PASSWORD: ponytest
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ponytest -d pony_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  cockroach:
+    image: cockroachdb/cockroach:latest
+    command: start-single-node --insecure
+    ports:
+      - "26257:26257"
+    healthcheck:
+      test: ["CMD", "cockroach", "sql", "--insecure", "--execute=SELECT 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 12

--- a/pony/orm/tests/config/cockroach.py
+++ b/pony/orm/tests/config/cockroach.py
@@ -1,0 +1,9 @@
+import os
+settings = {
+    'provider': 'cockroach',
+    'host': os.environ.get('PONY_TEST_HOST', 'localhost'),
+    'port': 26257,
+    'user': 'root',
+    'database': 'defaultdb',
+    'sslmode': 'disable',
+}

--- a/pony/orm/tests/config/mysql.py
+++ b/pony/orm/tests/config/mysql.py
@@ -1,0 +1,8 @@
+import os
+settings = {
+    'provider': 'mysql',
+    'host': os.environ.get('PONY_TEST_HOST', 'localhost'),
+    'user': 'ponytest',
+    'passwd': 'ponytest',
+    'db': 'pony_test',
+}

--- a/pony/orm/tests/config/postgres.py
+++ b/pony/orm/tests/config/postgres.py
@@ -1,0 +1,8 @@
+import os
+settings = {
+    'provider': 'postgres',
+    'host': os.environ.get('PONY_TEST_HOST', 'localhost'),
+    'user': 'ponytest',
+    'password': 'ponytest',
+    'database': 'pony_test',
+}

--- a/pony/orm/tests/test_bugs_mysql.py
+++ b/pony/orm/tests/test_bugs_mysql.py
@@ -1,0 +1,114 @@
+"""
+Regression tests for MySQL-specific bugs.
+
+These tests currently fail and serve as acceptance criteria for the fixes:
+  - BLOB/TEXT columns used as primary keys or in unique indexes (MySQL error 1170)
+  - DATE - DATE subtraction using TIMEDIFF instead of DATEDIFF
+"""
+import sys
+import unittest
+from datetime import date, timedelta
+
+from pony import orm
+from pony.orm import *
+from pony.orm.tests import setup_database, teardown_database, db_params
+
+
+class TestMySQLBlobPrimaryKey(unittest.TestCase):
+    """MySQL requires a key-length prefix for BLOB/TEXT columns in indexes (error 1170).
+    The ORM should emit the appropriate prefix automatically."""
+
+    def setUp(self):
+        self.db = orm.Database()
+
+        class Item(self.db.Entity):
+            data = orm.PrimaryKey(orm.buffer)
+
+        setup_database(self.db)
+
+    def tearDown(self):
+        teardown_database(self.db)
+
+    def test_buffer_primary_key_roundtrip(self):
+        """Insert and retrieve an entity whose primary key is a BLOB."""
+        Item = self.db.Item
+        buf = orm.buffer(b'hello world')
+        with db_session:
+            Item(data=buf)
+        with db_session:
+            item = Item[buf]
+            self.assertEqual(item.data, buf)
+
+
+class TestMySQLBlobUniqueIndex(unittest.TestCase):
+    """Same key-length requirement applies when a BLOB/TEXT column has a unique index."""
+
+    def setUp(self):
+        self.db = orm.Database()
+
+        class Item(self.db.Entity):
+            id = orm.PrimaryKey(int)
+            data = orm.Optional(orm.buffer, unique=True)
+
+        setup_database(self.db)
+
+    def tearDown(self):
+        teardown_database(self.db)
+
+    def test_buffer_unique_roundtrip(self):
+        """Insert two rows with distinct BLOB values and look one up by value."""
+        Item = self.db.Item
+        buf1 = orm.buffer(b'value1')
+        buf2 = orm.buffer(b'value2')
+        with db_session:
+            Item(id=1, data=buf1)
+            Item(id=2, data=buf2)
+        with db_session:
+            item = Item.get(data=buf1)
+            self.assertIsNotNone(item)
+            self.assertEqual(item.id, 1)
+
+
+@unittest.skipIf(sys.version_info >= (3, 13), "Python 3.13 decompiler not supported")
+class TestMySQLDateSubtraction(unittest.TestCase):
+    """MySQL DATE_DIFF translates to TIMEDIFF, which returns a TIME value.
+    Date-minus-date comparisons need DATEDIFF (returns integer days) instead."""
+
+    def setUp(self):
+        self.db = orm.Database()
+
+        class Event(self.db.Entity):
+            name = orm.Required(str)
+            start = orm.Required(date)
+            end = orm.Required(date)
+
+        setup_database(self.db)
+
+        with db_session:
+            Event(name='short', start=date(2024, 1, 1), end=date(2024, 1,  3))  # 2 days
+            Event(name='long',  start=date(2024, 1, 1), end=date(2024, 1, 15))  # 14 days
+
+    def tearDown(self):
+        teardown_database(self.db)
+
+    @db_session
+    def test_date_diff_greater_than(self):
+        Event = self.db.Event
+        result = select(e.name for e in Event if e.end - e.start > timedelta(days=7))[:]
+        self.assertEqual(result, ['long'])
+
+    @db_session
+    def test_date_diff_less_than(self):
+        Event = self.db.Event
+        result = select(e.name for e in Event if e.end - e.start < timedelta(days=7))[:]
+        self.assertEqual(result, ['short'])
+
+    @db_session
+    def test_date_diff_equals(self):
+        Event = self.db.Event
+        result = select(e.name for e in Event if e.end - e.start == timedelta(days=2))[:]
+        self.assertEqual(result, ['short'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pony/orm/tests/test_diagram.py
+++ b/pony/orm/tests/test_diagram.py
@@ -86,7 +86,6 @@ class TestDiag(unittest.TestCase):
         db.bind(**db_params)
         db.generate_mapping()
 
-    @raises_exception(MappingError, 'Table name "Table1" is already in use')
     def test_diagram7(self):
         db = Database()
         class Entity1(db.Entity):
@@ -97,7 +96,12 @@ class TestDiag(unittest.TestCase):
             id = PrimaryKey(int)
             attr2 = Set(Entity1, table='Table1')
         db.bind(**db_params)
-        db.generate_mapping()
+        try:
+            db.generate_mapping()
+            self.fail("Expected MappingError wasn't raised")
+        except MappingError as e:
+            self.assertIn('Table1', str(e))
+            self.assertIn('is already in use', str(e))
 
     def test_diagram8(self):
         db = Database()

--- a/pony/orm/tests/test_indexes.py
+++ b/pony/orm/tests/test_indexes.py
@@ -70,6 +70,8 @@ class TestIndexes(unittest.TestCase):
         if pony.__version__ < '0.9':
             if dialect == 'SQLite':
                 index_sql = 'CREATE INDEX "idx_person__name_age" ON "Person" ("name", "age")'
+            elif dialect == 'MySQL':
+                index_sql = 'CREATE INDEX `idx_person__name_age` ON `person` (`name`, `age`)'
             else:
                 index_sql = 'CREATE INDEX "idx_person__name_age" ON "person" ("name", "age")'
         elif dialect == 'MySQL' or dialect == 'SQLite':

--- a/pony/orm/tests/test_json.py
+++ b/pony/orm/tests/test_json.py
@@ -619,8 +619,10 @@ class TestJson(unittest.TestCase):
         last_sql = db.last_sql
         if db.provider.dialect == 'PostgreSQL':
             self.assertTrue(')::text' in last_sql)
+        elif db.provider.dialect == 'MySQL':
+            self.assertTrue('AS CHAR' in last_sql)
         else:
-            self.assertTrue('AS text' in db.last_sql)
+            self.assertTrue('AS text' in last_sql)
 
     @db_session
     def test_int_cast(self):
@@ -628,6 +630,8 @@ class TestJson(unittest.TestCase):
         last_sql = db.last_sql
         if db.provider.dialect == 'PostgreSQL':
             self.assertTrue(')::int' in last_sql)
+        elif db.provider.dialect == 'MySQL':
+            self.assertTrue('AS SIGNED' in last_sql)
         else:
             self.assertTrue('as integer' in last_sql)
 

--- a/pony/orm/tests/test_prefetching.py
+++ b/pony/orm/tests/test_prefetching.py
@@ -131,7 +131,7 @@ class TestPrefetching(unittest.TestCase):
 FROM "%s" "s"
 ORDER BY 1
 LIMIT 1''' % table_name
-        if db.provider.dialect == 'SQLite' and pony.__version__ >= '0.9':
+        if db.provider.dialect == 'MySQL' or (db.provider.dialect == 'SQLite' and pony.__version__ >= '0.9'):
             expected_sql = expected_sql.replace('"', '`')
         self.assertEqual(db.last_sql, expected_sql)
 

--- a/pony/orm/tests/test_volatile.py
+++ b/pony/orm/tests/test_volatile.py
@@ -27,7 +27,8 @@ class TestVolatile1(unittest.TestCase):
     def test_1(self):
         db = self.db
         Item = db.Item
-        db.execute('update "item" set "index" = "index" + 1')
+        q = db.provider.quote_name
+        db.execute('update %s set %s = %s + 1' % (q('item'), q('index'), q('index')))
         items = Item.select(lambda item: item.index > 0).order_by(Item.id)[:]
         a, b, c = items
         self.assertEqual(a.index, 2)


### PR DESCRIPTION
  Adds a Docker-based test matrix and fixes several test failures when running against MySQL/PostgreSQL/CockroachDB.

  Infrastructure
  - Dockerfile — parameterized by PYTHON_VERSION (defaults to 3.12), installs pony + test deps, runs pytest
  - docker-compose.yml — MySQL 8, PostgreSQL 15, CockroachDB with healthchecks
  - Makefile — targets for the full version × DB matrix (test-3.12-mysql, test-3.11-postgres, etc.), local DB shortcuts (test-sqlite, test-mysql, …), and infra helpers (docker-up, docker-down, clean)
  - pony/orm/tests/config/{mysql,postgres,cockroach}.py — per-backend connection settings, hostname overrideable via PONY_TEST_HOST for Docker networking

  Test fixes
  - test_volatile.py — use provider.quote_name instead of hardcoded double-quotes so the raw SQL works across dialects
  - test_prefetching.py — apply MySQL backtick quoting in the expected SQL, same as already done for SQLite
  - test_json.py — add MySQL branches for AS CHAR (string cast) and AS SIGNED (int cast) assertions
  - test_indexes.py — add MySQL branch for expected index DDL with backtick quoting
  - test_diagram.py — rewrite test_diagram7 to use explicit try/except instead of the @raises_exception decorator, which wasn't compatible under newer Python versions

  New test file
  - test_bugs_mysql.py — regression tests for two known MySQL issues: BLOB/TEXT columns as primary keys or unique indexes (error 1170), and DATE - DATE subtraction using DATEDIFF vs TIMEDIFF; the date subtraction tests are skipped on Python 3.13 pending decompiler support